### PR TITLE
build: uplift CodeBuild to v7.0

### DIFF
--- a/infra-control-plane/terraform/modules/pipeline/codebuild.tf
+++ b/infra-control-plane/terraform/modules/pipeline/codebuild.tf
@@ -13,7 +13,7 @@ resource "aws_codebuild_project" "build" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:7.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
   }


### PR DESCRIPTION
We should be running AWS CodeBuild on `aws/codebuild/standard:7.0`, which includes the right version of Nodejs

See: [ubuntu/standard/7.0/runtimes.yml](https://github.com/aws/aws-codebuild-docker-images/blob/master/ubuntu/standard/7.0/runtimes.yml)